### PR TITLE
Add support for embedded style blocks and files with asset pipeline digests

### DIFF
--- a/awesomemailer.gemspec
+++ b/awesomemailer.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = "awesomemailer"
-  s.version = "0.1.4"
+  s.version = "0.1.5"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Flip Sasser"]

--- a/lib/awesome_mailer/renderer.rb
+++ b/lib/awesome_mailer/renderer.rb
@@ -112,14 +112,18 @@ module AwesomeMailer
       stylesheet_path.gsub!(/^#{Regexp.escape(host)}/, '') if host
       case stylesheet_path
       when asset_pipeline_path
+        Rails.logger.debug 'In asset pipeline: ' + stylesheet_path
         if asset = read_asset_pipeline_asset(stylesheet_path)
           css_parser.add_block!(asset.to_s)
         end
       when /^\//
+
         local_path = rails? && Rails.root.join('public', stylesheet_path.gsub(/^\//, '')).to_s
+        Rails.logger.debug 'in local path: ' + local_path
         css_parser.load_file!(local_path) if local_path && File.file?(local_path)
       else
         dirname = File.dirname(stylesheet['href'])
+        Rails.logger.debug 'in else path: ' + dirname
         css_parser.load_uri!(stylesheet['href'], base_uri: dirname)
       end
       stylesheet.remove

--- a/lib/awesome_mailer/renderer.rb
+++ b/lib/awesome_mailer/renderer.rb
@@ -74,7 +74,7 @@ module AwesomeMailer
 
     def asset_pipeline_path
       return false unless sprockets?
-      /^#{Regexp.escape(Rails.configuration.assets[:prefix])}\//
+      /^\/#{Regexp.escape(Rails.configuration.assets[:prefix])}\//
     end
 
     def css_parser

--- a/lib/awesome_mailer/renderer.rb
+++ b/lib/awesome_mailer/renderer.rb
@@ -114,6 +114,8 @@ module AwesomeMailer
       when asset_pipeline_path
         if asset = read_asset_pipeline_asset(stylesheet_path)
           css_parser.add_block!(asset.to_s)
+        else
+          Rails.logger.error 'AwesomeMailer error. Could not find: ' + stylesheet_path if rails?
         end
       when /^\//
 

--- a/lib/awesome_mailer/renderer.rb
+++ b/lib/awesome_mailer/renderer.rb
@@ -112,18 +112,15 @@ module AwesomeMailer
       stylesheet_path.gsub!(/^#{Regexp.escape(host)}/, '') if host
       case stylesheet_path
       when asset_pipeline_path
-        Rails.logger.error 'In asset pipeline: ' + stylesheet_path
         if asset = read_asset_pipeline_asset(stylesheet_path)
           css_parser.add_block!(asset.to_s)
         end
       when /^\//
 
         local_path = rails? && Rails.root.join('public', stylesheet_path.gsub(/^\//, '')).to_s
-        Rails.logger.error 'in local path: ' + local_path
         css_parser.load_file!(local_path) if local_path && File.file?(local_path)
       else
         dirname = File.dirname(stylesheet['href'])
-        Rails.logger.error 'in else path: ' + dirname
         css_parser.load_uri!(stylesheet['href'], base_uri: dirname)
       end
       stylesheet.remove
@@ -134,8 +131,12 @@ module AwesomeMailer
     end
 
     def read_asset_pipeline_asset(path)
-      path = path.gsub(asset_pipeline_path, '')
+      path = path.gsub(asset_pipeline_path, '').gsub(digest_string, '')
       Rails.application.assets[path]
+    end
+
+    def digest_string
+      /-[A-Fa-f0-9]{32}/
     end
 
     def rewrite_relative_urls(css_declarations)

--- a/lib/awesome_mailer/renderer.rb
+++ b/lib/awesome_mailer/renderer.rb
@@ -112,18 +112,18 @@ module AwesomeMailer
       stylesheet_path.gsub!(/^#{Regexp.escape(host)}/, '') if host
       case stylesheet_path
       when asset_pipeline_path
-        Rails.logger.debug 'In asset pipeline: ' + stylesheet_path
+        Rails.logger.error 'In asset pipeline: ' + stylesheet_path
         if asset = read_asset_pipeline_asset(stylesheet_path)
           css_parser.add_block!(asset.to_s)
         end
       when /^\//
 
         local_path = rails? && Rails.root.join('public', stylesheet_path.gsub(/^\//, '')).to_s
-        Rails.logger.debug 'in local path: ' + local_path
+        Rails.logger.error 'in local path: ' + local_path
         css_parser.load_file!(local_path) if local_path && File.file?(local_path)
       else
         dirname = File.dirname(stylesheet['href'])
-        Rails.logger.debug 'in else path: ' + dirname
+        Rails.logger.error 'in else path: ' + dirname
         css_parser.load_uri!(stylesheet['href'], base_uri: dirname)
       end
       stylesheet.remove

--- a/lib/awesome_mailer/renderer.rb
+++ b/lib/awesome_mailer/renderer.rb
@@ -12,6 +12,11 @@ module AwesomeMailer
         # Must be intended for digital screens!
         load_stylesheet(stylesheet) if stylesheet['media'] =~ /^(all|handheld|screen)$/
       end
+      inline_stylesheets = document.search('style')
+      inline_stylesheets.each do |styles|
+        css_parser.add_block!(styles.inner_html)
+        styles.remove
+      end
       apply_css!(document)
     end
 

--- a/spec/lib/awesome_mailer_spec.rb
+++ b/spec/lib/awesome_mailer_spec.rb
@@ -100,4 +100,11 @@ describe AwesomeMailer::Base do
       %{<style type=\"text/css\">\np { -ms-border-radius: 5px; -o-border-radius: 5px; -moz-border-radius: 5px; -webkit-border-radius: 5px; }\n</style>}
     )
   end
+
+  context "when styles are embedded in the template" do
+    it "should include in parsed email" do
+      email = TestMailer.render_template(:embedded_styles).body.to_s
+      email.should == wrap_in_html('<div style="border: 1px solid #f00;">welcome!</div>')
+    end
+  end
 end

--- a/spec/views/test_mailer/embedded_styles.html.erb
+++ b/spec/views/test_mailer/embedded_styles.html.erb
@@ -1,0 +1,6 @@
+<style type="text/css">
+  div {
+    border: 1px solid #f00;
+  }
+</style>
+<div>welcome!</div>


### PR DESCRIPTION
Tests for asset pipeline are broken due to need to strip leading backslash on href. Perhaps there is a way to handle hrefs with or without leading backslash. 

Test for embedded style block are working.

Test for remote file is broken in that the url's for assets are not being rewritten to point to the asset host. This appears to be failing in pre-forked code, but I can't guarantee it. 

I bumped the version so that I could ensure that I was getting the correct version installed on the production servers. I apologize for that change. 
